### PR TITLE
add compiled dist for node 4.8 - 6.10

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,11 @@
+{
+  "presets": [
+    ["env", {
+      "targets": {
+        "node": "4.8.3",
+      },
+    }]
+  ],
+  "ignore": [],
+  "retainLines": 'true',
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,1 @@
 node_modules
-dist

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ await pda.readFile(archive, '/hello.txt') // read the committed hello.txt
 await pda.readFile(staging, '/hello.txt') // read the local hello.txt
 ```
 
+** NOTE: this library is written natively for node 7 and above. **
+
+To use with node versions lesser than 7 use:
+```js
+var pda = require('pauls-dat-api/es5');
+```
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -343,7 +350,7 @@ var emitStream = require('emit-stream')
 var events = emitStream(es)
 events.on('invalidated', args => {
   console.log(args.path, 'has been invalidated')
-  pda.download(archive, args.path)  
+  pda.download(archive, args.path)
 })
 events.on('changed', args => {
   console.log(args.path, 'has changed')

--- a/es5.js
+++ b/es5.js
@@ -1,0 +1,15 @@
+require("babel-polyfill");
+
+module.exports = Object.assign({},
+  require('./dist/const'),
+  require('./dist/common'),
+  require('./dist/staging'),
+  require('./dist/lookup'),
+  require('./dist/read'),
+  require('./dist/write'),
+  require('./dist/delete'),
+  require('./dist/network'),
+  require('./dist/act-stream'),
+  require('./dist/manifest'),
+  require('./dist/export')
+)

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Library of functions that make working with dat / hyperdrive easier.",
   "main": "index.js",
   "scripts": {
+    "prepublish": "npm run babel",
+    "babel": "rm -rf ./dist && babel lib --out-dir dist --copy-files",
     "test": "ava -s test/*.test.js"
   },
   "repository": {
@@ -35,6 +37,9 @@
   },
   "devDependencies": {
     "ava": "^0.18.1",
+    "babel-cli": "^6.24.1",
+    "babel-polyfill": "^6.23.0",
+    "babel-preset-env": "^1.5.1",
     "hyperdrive": "^9.0.0",
     "hyperdrive-staging-area": "^1.1.1"
   }


### PR DESCRIPTION
This should add the functionality discussed in https://github.com/beakerbrowser/pauls-dat-api/issues/13.

Users of node 4 - 6 can now import transpiled code via `var pda = require(‘pauls-dat-api/es5’);`.

Let me know if there are any issues, and I will address them right away. 

Again thanks for building such a nice collection of helper functions, they really have been really useful.