### PR TITLE
update package to include babel-polyfill as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/pfrazee/pauls-dat-api#readme",
   "dependencies": {
     "anymatch": "^1.3.0",
+    "babel-polyfill": "^6.23.0",
     "beaker-error-constants": "^1.1.0",
     "call-me-maybe": "^1.0.1",
     "co": "^4.6.0",
@@ -38,7 +39,6 @@
   "devDependencies": {
     "ava": "^0.18.1",
     "babel-cli": "^6.24.1",
-    "babel-polyfill": "^6.23.0",
     "babel-preset-env": "^1.5.2",
     "hyperdrive": "^9.4.1",
     "hyperdrive-staging-area": "^1.2.1"


### PR DESCRIPTION
I just realised that the es5 compatibility that I added a few months ago is broken for anyone who does not have babel-polyfill in their package.
This is a simple fix to remedy that problem. Sorry for the silly mistake.