### PR TITLE
Implemented createReaddirStream for bigger directory trees.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ var pda = require('pauls-dat-api/es5');
 - [Read](#read)
   - [readFile(archive, name[, opts, cb])](#readfilearchive-name-opts-cb)
   - [readdir(archive, path[, opts, cb])](#readdirarchive-path-opts-cb)
+  - [createReaddirStream(archive[, path, opts])](#createreaddirstreamarchive-path-opts)
   - [readSize(archive, path[, cb])](#readsizearchive-path-cb)
 - [Write](#write)
   - [writeFile(archive, name, data[, opts, cb])](#writefilearchive-name-data-opts-cb)
@@ -216,6 +217,35 @@ console.log(listing) /* => [
   'assets/profile.png',
   'assets/styles.css'
 ]*/
+```
+
+### createReaddirStream(archive[, path, opts])
+
+ - `archive` Hyperdrive archive (object).
+ - `path` Target directory path (string), defaults to `/`.
+ - `opts.recursive` Read all subfolders and their files as well?
+ - `opts.maxDepth` Limit the depth until which to look into folders.
+ - `opts.depthFirst` Using a [depth-first search](https://en.wikipedia.org/wiki/Depth-first_search) instead of the default [breadth-first search](https://en.wikipedia.org/wiki/Breadth-first_search).
+ - Returns a [readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable) in [`Object Mode`](https://nodejs.org/api/stream.html#stream_object_mode). The payload per entry is an object:
+     - `entry.location` The path of the entry
+     - `entry.stats` A [Stats](https://nodejs.org/api/fs.html#fs_class_fs_stats) object for that path
+
+```js
+var stream = pda.createReaddirStream(archive, '/assets')
+stream.on('data', ({location, stat}) => {
+  console.log(location) // => 'profile.png', 'styles.css'
+  console.log(stat.isDirectory()) // => false, false
+})
+
+var stream = pda.createReaddirStream(archive, { recursive: true })
+stream.on('data', ({location, stat}) => {
+  console.log(location) // => 'assets', 'index.html', 'assets/profile.png', 'assets/styles.css'
+})
+
+var stream = pda.createReaddirStream(archive, { recursive: true, depthFirst: true })
+stream.on('data', ({location, stat}) => {
+  console.log(location) // => 'assets', 'assets/profile.png', 'assets/styles.css', 'index.html'
+})
 ```
 
 ### readSize(archive, path[, cb])

--- a/lib/read.js
+++ b/lib/read.js
@@ -4,6 +4,7 @@ const path = require('path')
 const {NotAFileError} = require('beaker-error-constants')
 const {toBeakerError, toValidEncoding} = require('./common')
 const {stat} = require('./lookup')
+const {Readable} = require('stream')
 
 // helper to pull file data from an archive
 function readFile (archive, name, opts, cb) {
@@ -33,6 +34,96 @@ function readFile (archive, name, opts, cb) {
       })
     })
   }))
+}
+
+function createReaddirStream (archive, name, opts) {
+  if (name !== null && typeof name === 'object') {
+    return createReaddirStream(archive, null, name)
+  }
+  if (!opts) {
+    return createReaddirStream(archive, name, {})
+  }
+  if (typeof name !== 'string') {
+    return createReaddirStream(archive, '/', opts)
+  }
+
+  var destroyed = false
+  var paused = false
+  // Queue of the entries to check if they are a directory or not
+  var queue
+
+  const recursive = opts.recursive || false
+  const depthFirst = opts.depthFirst || false
+  const maxDepth = opts.maxDepth || 0
+  const stream = new Readable({
+    read,
+    destroy: end,
+    objectMode: true
+  })
+  // Immediately read the root folder
+  readFolder(name, 0)
+  return stream
+
+  function read (size) {
+    if (paused) {
+      paused = false
+      process()
+    }
+  }
+
+  function end (err) {
+    if (!destroyed) {
+      queue = null
+      destroyed = true
+      if (err) {
+        stream.emit('error', err)
+      }
+      stream.push(null)
+    }
+  }
+
+  function process () {
+    if (paused || destroyed) return
+    if (queue.length === 0) {
+      return end()
+    }
+    var {location, depth} = queue.shift()
+    archive.stat(location, (err, stat) => {
+      if (err) {
+        return end(err)
+      }
+      if (stat) {
+        paused = !stream.push({location, stat})
+        if (stat.isDirectory() && recursive && (maxDepth === 0 || depth < maxDepth)) {
+          return readFolder(location, depth + 1)
+        }
+      }
+      process()
+    })
+  }
+
+  function readFolder (folder, depth) {
+    archive.readdir(folder, {recursive}, (err, names) => {
+      if (err) {
+        return end(err)
+      }
+      names = names.map(name => ({
+        depth,
+        location: path.join(folder, name)
+      }))
+
+      if (!queue) {
+        queue = names
+      } else if (depthFirst) {
+        queue = names.concat(queue)
+      } else {
+        queue = queue.concat(names)
+      }
+      if (!paused) {
+        process()
+      }
+    })
+  }
 }
 
 // helper to list the files in a directory
@@ -104,4 +195,4 @@ function normalize (rootPath, parentPath, subname) {
   return str
 }
 
-module.exports = {readFile, readdir, readSize}
+module.exports = {readFile, readdir, readSize, createReaddirStream}

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -235,6 +235,355 @@ test('readSize', async t => {
   t.truthy(size3 > 0)
 })
 
+{
+  test('createReaddirStream › regular', async t => {
+    const archive = await tutil.createArchive([
+      'a',
+      'b',
+      'c/',
+      'c/a'
+    ])
+
+    await compareStreamEntries(
+      t,
+      pda.createReaddirStream(archive),
+      ['/a', '/b', '!/c']
+    )
+    await compareStreamEntries(
+      t,
+      pda.createReaddirStream(archive, ''),
+      ['a', 'b', '!c']
+    )
+  })
+
+  test('createReaddirStream › single hierarchy', async t => {
+    const archive = await tutil.createArchive([
+      'a',
+      'b',
+      'c'
+    ])
+
+    await compareStreamEntries(
+      t,
+      pda.createReaddirStream(archive),
+      ['/a', '/b', '/c']
+    )
+  })
+
+  test('createReaddirStream › recursive', async t => {
+    const archive = await tutil.createArchive([
+      'a',
+      'b',
+      'c/',
+      'c/a',
+      'd'
+    ])
+
+    await compareStreamEntries(
+      t,
+      pda.createReaddirStream(archive, {recursive: true}),
+      ['/a', '/b', '!/c', '/d', '/c/a']
+    )
+  })
+
+  test('createReaddirStream › recursive + depthFirst', async t => {
+    const archive = await tutil.createArchive([
+      'a',
+      'b',
+      'c/',
+      'c/x/',
+      'c/x/1',
+      'c/y',
+      'd'
+    ])
+
+    await compareStreamEntries(
+      t,
+      pda.createReaddirStream(archive, {recursive: true, depthFirst: true}),
+      ['/a', '/b', '!/c', '!/c/x', '/c/x/1', '/c/y', '/d']
+    )
+  })
+
+  test('createReaddirStream › recursive + maxDepth', async t => {
+    const archive = await tutil.createArchive([
+      'a/',
+      'a/b',
+      'a/c/',
+      'a/c/d',
+      'a/c/e/',
+      'a/c/e/f',
+      'o'
+    ])
+
+    // Default case = full depth
+    await compareStreamEntries(
+      t,
+      pda.createReaddirStream(archive, {recursive: true}),
+      [
+        '!/a',
+        '/o',
+        '/a/b',
+        '!/a/c',
+        '/a/c/d',
+        '!/a/c/e',
+        '/a/c/e/f'
+      ]
+    )
+
+    // One depth should be one past the current director (else you would need to switch recursive=false)
+    await compareStreamEntries(
+      t,
+      pda.createReaddirStream(archive, {recursive: true, maxDepth: 1}),
+      [
+        '!/a',
+        '/o',
+        '/a/b',
+        '!/a/c'
+      ]
+    )
+
+    // Test with two levels
+    await compareStreamEntries(
+      t,
+      pda.createReaddirStream(archive, {recursive: true, maxDepth: 2}),
+      [
+        '!/a',
+        '/o',
+        '/a/b',
+        '!/a/c',
+        '/a/c/d',
+        '!/a/c/e'
+      ]
+    )
+  })
+
+  function compareStreamEntries (t, stream, entries) {
+    return new Promise((resolve, reject) => {
+      let current = 0
+      stream.on('data', entry => {
+        if (entries.length === current) {
+          t.fail(`Unexpected entry ${entry}`)
+          return
+        }
+        current = compareReaddirStreamEntry(t, entries, current, entry)
+      })
+      stream.on('error', reject)
+      stream.on('end', () => {
+        if (current < entries.length) {
+          t.fail(`Missing ${entries.length - current} entries: [ ${entries.slice(current).map(entry => `'${entry}'`).join(', ')} ]`)
+        } else {
+          t.pass('all entries processed')
+        }
+        resolve()
+      })
+    })
+  }
+}
+
+test('createReaddirStream › err .readdir', t => {
+  const archive = {
+    readdir (name, opts, cb) {
+      t.is(name, '/')
+      setImmediate(() => cb(new Error('error-test')))
+    }
+  }
+  const stream = pda.createReaddirStream(archive)
+  let errorCalled = false
+  return new Promise(resolve => {
+    stream.on('data', data => t.fail(`Unexpected data occured ${data}`))
+    stream.on('error', e => {
+      t.is(e.message, 'error-test')
+      errorCalled = true
+    })
+    stream.on('end', () => {
+      t.true(errorCalled, 'Error should have been called.')
+      resolve()
+    })
+  })
+})
+
+test('createReaddirStream › err .stat', t => {
+  const archive = {
+    stat (name, cb) {
+      t.is(name, '/x')
+      setImmediate(() => cb(new Error('error-test')))
+    },
+    readdir (name, opts, cb) {
+      setImmediate(() => cb(null, ['/x']))
+    }
+  }
+  const stream = pda.createReaddirStream(archive)
+  let errorCalled = false
+  return new Promise(resolve => {
+    stream.on('data', data => t.fail(`Unexpected data occured ${data}`))
+    stream.on('error', e => {
+      t.is(e.message, 'error-test')
+      errorCalled = true
+    })
+    stream.on('end', () => {
+      t.true(errorCalled, 'Error should have been called.')
+      resolve()
+    })
+  })
+})
+
+test('createReaddirStream › destroy immediately', t => {
+  const archive = {
+    readdir (name, opts, cb) {
+      setImmediate(() => cb(null, ['/x']))
+    }
+  }
+  const stream = pda.createReaddirStream(archive)
+  return new Promise((resolve, reject) => {
+    stream.on('data', data => t.fail(`Unexpected data occured ${data}`))
+    stream.on('error', reject)
+    stream.on('end', resolve)
+    stream.destroy()
+  })
+})
+
+test('createReaddirStream › destroy after first read', t => {
+  const archive = {
+    stat (name, cb) {
+      t.not(name, 'b/c', 'c is not expected as the stream should be destroyed by then')
+      setImmediate(() => {
+        cb(null, {
+          isFile: () => name === 'a',
+          isDirectory: () => name === 'b'
+        })
+      })
+    },
+    readdir (name, opts, cb) {
+      let result
+      if (name === '/') {
+        result = ['a', 'b']
+      } else if (name === 'b') {
+        return cb(new Error(`Readdir called for unexpected ${name}`))
+      }
+      setImmediate(() => cb(null, result))
+    }
+  }
+  return new Promise(resolve => {
+    const stream = pda.createReaddirStream(archive)
+    stream.on('data', data => {
+      t.not(data, '/b/c')
+      if (data === 'b') {
+        stream.destroy()
+      } else {
+        t.is(data, '/a')
+      }
+    })
+    stream.on('error', e => t.fail(e))
+    stream.on('end', resolve)
+    stream.destroy()
+  })
+})
+
+test('createReaddirStream › pause', async t => {
+  const archive = await tutil.createArchive([
+    'a',
+    'b',
+    'c/',
+    'c/x/',
+    'c/x/1',
+    'c/y',
+    'd'
+  ])
+
+  await readWithPause(pda.createReaddirStream(archive, {recursive: true}), [
+    ['/a', '/b', '!/c', '/d'],
+    ['!/c/x', '/c/y'],
+    ['/c/x/1']
+  ])
+
+  await readWithPause(pda.createReaddirStream(archive, {recursive: true, depthFirst: true}), [
+    ['/a', '/b', '!/c'],
+    ['!/c/x', '/c/x/1'],
+    ['/c/y', '/d']
+  ])
+
+  function readWithPause (stream, blocks) {
+    return new Promise(resolve => {
+      let current = 0
+      let blockNr = 0
+      let entries = blocks.shift()
+      stream.on('data', entry => {
+        if (entries.length === current) {
+          t.fail(`Unexpected entry ${entry} in block#${blockNr}`)
+          return
+        }
+        current = compareReaddirStreamEntry(t, entries, current, entry)
+        if (!stream.isPaused() && blocks.length > 0 && entries.length > 0) {
+          stream.pause()
+          setTimeout(() => {
+            entries = entries.concat(blocks.shift())
+            blockNr += 1
+            stream.resume()
+          }, 200)
+        }
+      })
+      stream.on('error', e => t.fail(e))
+      stream.on('end', resolve)
+      stream.pause()
+      setTimeout(() => stream.resume(), 200)
+    })
+  }
+})
+
+/*
+test('createReaddirStream › huge tree', async t => {
+  function createTree (result, root, depth) {
+    for (let fileNo = 0; fileNo < 10; fileNo += 1) {
+      result.push(`${root}file_${fileNo}`)
+    }
+    for (let dirNo = 0; dirNo < 3; dirNo += 1) {
+      const name = `${root}dir_${dirNo}/`
+      result.push(name)
+      if (depth > 0) {
+        createTree(result, name, depth - 1)
+      }
+    }
+    return result
+  }
+
+  const startA = Date.now()
+  const list = createTree([], '', 5)
+  console.log(`${Date.now() - startA} ms for creating archive (${list.length})`)
+
+  const startB = Date.now()
+  const archive = await tutil.createArchive(list)
+  console.log(`${Date.now() - startB} ms for creating archive (${list.length})`)
+
+  const done = new Promise((resolve, reject) => {
+    const stream = archive.createReaddirStream(archive)
+    let count = 0
+    stream.on('data', entry => {
+      console.log(entry)
+      if (count > 500) {
+        stream.pause()
+      }
+      count += 1
+    })
+    stream.on('end', resolve)
+  })
+  await done
+})
+*/
+
+function compareReaddirStreamEntry (t, entries, current, entry) {
+  let expected = entries[current]
+  const isDir = /^!/.test(expected)
+  if (isDir) {
+    expected = expected.substr(1)
+  }
+  t.deepEqual(entry.location, expected, `comparing entry ${current}`)
+  if (isDir) {
+    t.true(entry.stat.isDirectory(), `Expected #${current} - ${expected} to be a directory`)
+  } else {
+    t.true(entry.stat.isFile(), `Expected #${current} - ${expected} to be a file`)
+  }
+  return current + 1
+}
 
 function stripPrecedingSlash (str) {
   if (str.charAt(0) == '/') return str.slice(1)


### PR DESCRIPTION
Once the file-tree grows it might be good to have a stream to read the directory structure. `hyperdrive` used to have this stream method but it doesn't anymore. This method should help out when a stream is more suited for a task.