### PR TITLE
Upgrade anymatch (major); fixes advisory #786.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/pfrazee/pauls-dat-api#readme",
   "dependencies": {
-    "anymatch": "^1.3.2",
+    "anymatch": "^2.0.0",
     "beaker-error-constants": "^1.4.0",
     "call-me-maybe": "^1.0.1",
     "dat-encoding": "^4.0.2",


### PR DESCRIPTION
Oups, it doesn't completely fix the advisory, an old chokidar is still using anymatch 1.x.